### PR TITLE
fix: make the published skeleton installable outside the monorepo

### DIFF
--- a/bin/post-create-setup.php
+++ b/bin/post-create-setup.php
@@ -63,3 +63,8 @@ if (!$hasAdminPackage) {
     echo "  Optional: set \033[33mWAASEYAA_ADMIN_PATH\033[0m to a Nuxt admin package for live-reload UI.\n";
 }
 echo "\n";
+
+$manifestCompiler = $root . '/vendor/bin/waaseyaa';
+if (is_file($manifestCompiler)) {
+    passthru(PHP_BINARY . ' ' . escapeshellarg($manifestCompiler) . ' optimize:manifest');
+}

--- a/bin/waaseyaa
+++ b/bin/waaseyaa
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+require dirname(__DIR__) . '/vendor/waaseyaa/cli/bin/waaseyaa';

--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,6 @@
     "description": "Waaseyaa CMS project skeleton",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../waaseyaa/packages/*",
-            "options": {
-                "symlink": true
-            }
-        }
-    ],
     "require": {
         "php": ">=8.4",
         "symfony/dotenv": "^8.0",


### PR DESCRIPTION
## Summary
- remove the monorepo-only path repository from the published skeleton
- add the missing in/waaseyaa wrapper referenced by scripts and docs
- compile the package manifest after project creation so app providers/routes are discoverable immediately

## Reproduction
1. Run composer create-project waaseyaa/waaseyaa my-app --stability=dev in a normal environment.
2. Composer fails because ../waaseyaa/packages/* does not exist in published installs.
3. Even after removing that manually, the skeleton references in/waaseyaa in scripts/docs but does not ship it.

## Why this fix
The published skeleton should not assume a local monorepo checkout. These changes make the package behave like the public install path described in the docs.